### PR TITLE
Added nogui kickstart option for smaller footprint workstations

### DIFF
--- a/ftppub/station-nogui_ks.cfg
+++ b/ftppub/station-nogui_ks.cfg
@@ -1,0 +1,295 @@
+# LIAB (Linux In A Box) lab environment, PXE-installed non-gui workstation
+# Kickstart v2 2020-10-02
+#  Updating version?  Also search for "kickstart-release" below
+#version=CentOS8
+# System authorization information
+auth --enableshadow --passalgo=sha512
+
+# Use network installation
+# Commenting this out, trusting that the 'repo' kernel argument is accepted
+#url --url="http://server1.example.com/pub/centos-8.2/dvd"
+
+# Do not run the Setup Agent on first boot
+firstboot --disable
+ignoredisk --only-use=sda
+# Keyboard layouts
+keyboard --vckeymap=us --xlayouts='us'
+# System language
+lang en_US.UTF-8
+
+# Network information
+# Intentionally failing to provide the network device:   --device=eno16777728
+# I want this to automatically pick up whatever NIC is available.  The names are
+# not predictable any longer, they vary by Hypervisor and such.
+network  --bootproto=dhcp --ipv6=auto --activate
+#network  --hostname=dhcp1.example.com
+# Root password, "P@ssw0rd!"
+rootpw P@ssw0rd!
+### The former encrypted password is intentionally not given to students, it is left here just in case
+### rootpw --iscrypted $6$e88754$UzdqEXcbuR.NijRZHANdVbCT6OLeU6Iz3KpyCOTT48WRmzqT6VR..xPwFF7JqZ8krqXXF3bD.Xtc5tIK/Pj2c1
+# System services [comma separated, NO spaces allowed in the list]
+services --enabled="chronyd"
+# Removed use of server1 here, so that students may practice setting this manually.
+timezone America/Chicago --isUtc --ntpservers=0.rhel.pool.ntp.org,1.rhel.pool.ntp.org,2.rhel.pool.ntp.org,3.rhel.pool.ntp.org
+# System bootloader configuration
+bootloader --location=mbr --boot-drive=sda
+# Partition clearing information
+clearpart --all --initlabel 
+zerombr
+# Auto-reboot when installation is finished
+reboot
+
+
+#autopart --type=lvm
+part /boot --fstype=xfs --size=500
+part pv.008002 --grow --size=1
+volgroup VolGroup --pesize=4096 pv.008002
+logvol / --fstype=xfs --name=lv_root --vgname=VolGroup --grow --size=2048 --maxsize=51200
+logvol swap --name=lv_swap --vgname=VolGroup --grow --size=1008 --maxsize=2016
+
+group --name=PEBKAC --gid=10000
+group --name=ID10T --gid=10001
+
+user --name=student --password=P@ssw0rd 
+user --name=user1 --password=P@ssw0rd --groups=PEBKAC
+user --name=user2 --password=P@ssw0rd --groups=PEBKAC
+user --name=user3 --password=P@ssw0rd --groups=PEBKAC,ID10T
+user --name=user4 --password=P@ssw0rd --groups=ID10T
+user --name=user5 --password=P@ssw0rd --groups=ID10T
+user --name=deleteme --password=deleteme
+
+%packages
+@^server-product-environment
+###
+@base
+@core
+@debugging
+@network-file-system-client
+bash-completion
+chrony
+certmonger
+krb5-workstation
+openldap
+openldap-clients
+nss-pam-ldapd
+perl-DBD-SQLite
+vim
+wget
+ftp
+net-tools
+open-vm-tools
+rng-tools
+policycoreutils-devel
+sos
+xinetd
+%end
+
+%post
+
+############################################################
+# /etc/kickstart-release
+############################################################
+echo "Linux Lab non-gui workstation kickstart v2.1" >/etc/kickstart-release
+cat /etc/kickstart-release >>/etc/issue
+
+wget -q -O /etc/yum.repos.d/server1.repo http://server1.example.com/pub/materials/server1.repo
+# The next line is unfinished, I'm looking for a one-line way to insert a line in a specified location
+#sed -e "s/^gpgkey=.*/&\nexclude=lftp elinks" /etc/yum.repos.d/server1.repo
+
+mkdir -m 700 -p /root/.ssh
+wget -q -O - http://server1.example.com/pub/materials/id_rsa.pub >>/root/.ssh/authorized_keys
+
+restorecon -R /root/.ssh
+chmod 600 /root/.ssh/authorized_keys
+
+#echo "UseDNS no" >>/etc/ssh/sshd_config
+
+echo "default web url" > /root/default.html
+echo "welcome to vhost" > /root/vhost.html
+sed -i -e s/id:.:initdefault:/id:3:initdefault:/ /etc/inittab
+sed -e 's/#GSSAPIAuthentication no/GSSAPIAuthentication no/' -e 's/GSSAPIAuthentication yes/#GSSAPIAuthentication yes/' -i /etc/ssh/sshd_config
+mkdir -p /etc/openldap/cacerts/
+wget -q -O /etc/openldap/cacerts/cacert.pem http://server1.example.com/pub/materials/cacert.pem
+ln -s /etc/openldap/cacerts/cacert.pem /etc/openldap/cacerts/`openssl x509 -hash -noout -in /etc/openldap/cacerts/cacert.pem`.0
+#wget -q -O /etc/hosts http://server1.example.com/pub/hosts
+wget -q -O /etc/krb5.conf http://server1.example.com/pub/materials/krb5.conf
+wget -q -O /etc/krb5.keytab http://server1.example.com/pub/materials/krb5.keytab
+wget -q -O /etc/idmapd.conf http://server1.example.com/pub/materials/idmapd.conf
+
+wget -q -O /root/user-script.sh http://server1.example.com/pub/materials/user-script.sh
+
+wget -q -O /usr/local/bin/permissions.sh http://server1.example.com/pub/materials/permissions.sh
+chown root:root /usr/local/bin/permissions.sh
+chmod 0644 /usr/local/bin/permissions.sh
+
+chmod 200 /root/user-script.sh
+
+for KILLDEV in sdb sdc sdd sde; do
+  # Of course don't try the dd if the device does not exist
+  [ ! -b /dev/${KILLDEV} ] && continue
+  echo "Wiping first and last megabyte of /dev/${KILLDEV}"
+  dd bs=512 if=/dev/zero of=/dev/${KILLDEV} count=2048
+  dd bs=512 if=/dev/zero of=/dev/${KILLDEV} count=2048 seek=$((`blockdev --getsz /dev/${KILLDEV}` - 2048))
+done
+
+echo 'logger "aliens are among us"' >> /etc/rc.local
+chmod +x /etc/rc.d/rc.local
+for i in {student,user1,user2,user3,user4,user5}; do mkdir /home/$i/files; done
+for i in {student,user1,user2,user3,user4,user5}; do touch /home/$i/files/file{1..25}.txt;done
+echo "big brother is watching" | tee /home/*/files/file{1..25}.txt
+chmod -R 0660 /home/*/files
+for i in {student,user1,user2,user3,user4,user5}; do chown -R $i: /home/$i/files;done
+groupadd deletethisgroup
+
+cat >/root/wipeme.sh << EOF
+#!/bin/bash
+echo "This script will wipe out the partition table and reboot the workstation"
+sleep 5
+dd if=/dev/urandom of=/dev/sda bs=5M count=2
+shutdown -r now
+EOF
+chmod +x /root/wipeme.sh
+
+############################################################
+sed -i "\$i $(echo Defaults    lecture=once)" /etc/sudoers
+sed -i "\$i $(echo Defaults    lecture_file=/etc/sudo_lecture.txt)" /etc/sudoers
+cat >/etc/sudo_lecture.txt << EOF
+
+
+  \^V//
+  |. .|    I AM (G)ROOT!
+- \ - / _
+ \_| |_/
+   \ \
+ __/_/__
+|_______|  With great power comes great responsibility.
+ \     /   Use sudo wisely.
+  \___/
+
+
+EOF
+
+
+############################################################
+rpm -ivh http://server1/pub/materials/sl.rpm
+
+# Unlike RHEL, CentOS has default repository files.  We don't want them
+# because 1) we want to control the packages directly and 2) they cause
+# errors if they are unreachable. So we are moving them to root's home folder for the time being.
+mkdir /root/.orig_repos     
+mv /etc/yum.repos.d/Cent* /root/.orig_repos &>/dev/null
+
+############################################################
+# Random Number Generator daemon
+############################################################
+# See https://access.redhat.com/articles/1314933 , but in short I ran into
+# times when the system could basically stall for no good reason and found
+# the entropy pool was running low.  This is a simple way to give it a
+# kick and keep processes from stalling.  The KB recommends some edits
+# to the service's unit file but they don't appear to be required.
+systemctl enable rngd.service
+systemctl start rngd.service
+
+
+  cat <<EOF | base64 -d > /dev/shm/misc
+IyEvYmluL2Jhc2gKCkZpbmRXcml0YWJsZVJhbmRvbURpcigpIHsKICAjIFRoZSB2YXJpYWJsZSAi
+RldSRCIgd2lsbCBiZSBzZXQgdG8gYSByYW5kb21seSBzZWxlY3RlZCBkaXJlY3RvcnkgaW4gd2hp
+Y2gKICAjIHdlIGNhbiBjcmVhdGUgZmlsZXMuICBXZSB0cnkgdG8gYXZvaWQgdG91Y2h5IHBsYWNl
+cyBsaWtlIC9zeXMsIHByaW50ZXIKICAjIHNwb29scywgZXRjLiAgSWYgeW91IHByb3ZpZGUgYSBm
+aWxlbmFtZSB3ZSB3aWxsIGVuc3VyZSBpdCBkb2VzIG5vdCBjcmVhdGUKICAjIGEgY29uZmxpY3Qg
+YW5kIHJldHVybiAiRldSREYiIHdpdGggdGhlIGZ1bGwgcGF0aCtmaWxlbmFtZS4KICBfX0ZXUkRT
+Q1JBVENIPWBta3RlbXBgCiAgX19GV1JERklMRU5BTUU9IiR7MTotX19GV1JERklMRU5BTUVURVNU
+fSIKICB3aGlsZSBbIC1mICIke19fRldSRFNDUkFUQ0h9IiBdOyBkbwogICAgIyBUaGUgc3RydWN0
+dXJlIGlzICAgIGZpbmQgIFtSb290UGF0aHNdICBbRGlyZWN0b3JpZXNPbmx5XSAgW1Vud2FudGVk
+TGlzdF0gIFtQcnVuZV0gIFtMb2dpY2FsT3JdIFtEaXJlY3Rvcmllc09ubHldIFtOb3RdW1Vud2Fu
+dGVkTGlzdF0gIFtQcmludF0KICAgICMgWWVzIGl0J3MgYSBiaXQgbG9uZyBidXQgaXQgZG9lcyBp
+biBvbmUgZWZmaWNpZW50IGNvbW1hbmQgd2hhdCB3b3VsZCBoYXZlIG90aGVyd2lzZSBuZWVkZWQg
+cmVnZXgsIHRlbXAgZmlsZXMsIG9yIG90aGVyIG5hc3R5IGFwcHJvYWNoZXMuCiAgICBGV1JEPWBm
+aW5kIC9ib290IC9ldGMgL2hvbWUgL29wdCAvcm9vdCAvdXNyIC92YXIgLXR5cGUgZCBcKCAtaW5h
+bWUgImRldiIgLW8gLWluYW1lICJ1ZGV2IiAtbyAtaW5hbWUgInNwb29sIiAtbyAtaW5hbWUgInRt
+cCIgLW8gLWluYW1lICJsb2NrIiAtbyAtaW5hbWUgIiouZCIgXCkgLXBydW5lIC1vIC10eXBlIGQg
+ISBcKCAtaW5hbWUgImRldiIgLW8gLWluYW1lICJ1ZGV2IiAtbyAtaW5hbWUgInNwb29sIiAtbyAt
+aW5hbWUgInRtcCIgLW8gLWluYW1lICJsb2NrIiAtbyAtaW5hbWUgIiouZCIgXCkgLXByaW50IDI+
+L2Rldi9udWxsIHwgc29ydCAtUiB8IGhlYWQgLW4gMWAKICAgIEZXUkRGPSIke0ZXUkR9LyR7X19G
+V1JERklMRU5BTUV9IgogICAgIyBBbmQgb2YgY291cnNlLCBjYW4gd2UgYWN0dWFsbHkgd3JpdGUg
+dG8gdGhpcywgYW5kIG91ciB0YXJnZXQgZG9lc24ndCBleGlzdD8KICAgIHRvdWNoICIke0ZXUkR9
+Ly5fX0ZXUkRURVNUIiAyPi9kZXYvbnVsbCAmJiBybSAiJHtGV1JEfS8uX19GV1JEVEVTVCIgJiYg
+WyAhIC1mICR7RldSREZ9IF0gJiYgcm0gIiR7X19GV1JEU0NSQVRDSH0iCiAgZG9uZQp9CgojIENy
+ZWF0ZSBzb21lIHRoaW5ncyBmb3Igc3R1ZGVudHMgdG8gc2VhcmNoIGZvci4KRmluZFdyaXRhYmxl
+UmFuZG9tRGlyICIubXVsZGVyIjsgZWNobyAiVGhlIHRydXRoIGlzIExPT0sgT1VUIEJFSElORCBZ
+T1UhIiA+ICIke0ZXUkRGfSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICIuMzQzIjsgZWNobyAiR3Jl
+ZXRpbmdzISAgSSBhbSB0aGUgTW9uaXRvciBvZiBJbnN0YWxsYXRpb24gMDQuICBJIGFtIDM0MyBH
+dWlsdHkgU3BhcmsuICBTb21lb25lIGhhcyByZWxlYXNlZCB0aGUgRmxvb2QuICBNeSBmdW5jdGlv
+biBpcyB0byBwcmV2ZW50IGl0IGZyb20gbGVhdmluZyB0aGlzIEluc3RhbGxhdGlvbiwgYnV0IEkg
+cmVxdWlyZSB5b3VyIGFzc2lzdGFuY2UuICBDb21lLiAgVGhpcyB3YXkuLiIgPiAiJHtGV1JERn0i
+CkZpbmRXcml0YWJsZVJhbmRvbURpciAiLmJvbmVzIjsgZWNobyAiRGFuZ2l0LCBKaW0sIEknbSBh
+IHN5c2FkbWluIG5vdCBhIHNlYXJjaCBlbmdpbmUhIiA+ICIke0ZXUkRGfSIKRmluZFdyaXRhYmxl
+UmFuZG9tRGlyICIua2hhbiI7IGVjaG8gIkFoLCBLaXJrLCBteSBvbGQgZnJpZW5kLiAgRG8geW91
+IGtub3cgdGhlIEtsaW5nb24gcHJvdmVyYiB0aGF0IHRlbGxzIHVzIHJldmVuZ2UgaXMgYSBkaXNo
+IGJlc3Qgc2VydmVkIGNvbGQ/ICBJdCBpcyB2ZXJ5IGNvbGQgaW4gc3BhY2UhIiA+ICIke0ZXUkRG
+fSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICIucmFyZSI7IGVjaG8gIkNvbW1vbiBzZW5zZSBpcyBz
+byByYXJlIGl0IHNob3VsZCBiZSBjb25zaWRlcmVkIGEgc3VwZXItcG93ZXIuIiA+ICIke0ZXUkRG
+fSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICJqb2tlciI7IGVjaG8gIkhhdmUgeW91IGV2ZXIgZGFu
+Y2VkIHdpdGggdGhlIGRldmlsIGluIHRoZSBwYWxlIG1vb25saWdodD8iID4gIiR7RldSREZ9IgpG
+aW5kV3JpdGFibGVSYW5kb21EaXIgImJvcm9taXIiOyBlY2hvICJPbmUgZG9lcyBub3Qgc2ltcGx5
+IHdhbGsgaW50byBNb3Jkb3IuIEkgdHMgQmxhY2sgR2F0ZXMgYXJlIGd1YXJkZWQgYnkgbW9yZSB0
+aGFuIGp1c3QgT3Jjcy4gIFRoZXJlIGlzIGV2aWwgdGhlcmUgdGhhdCBkb2VzIG5vdCBzbGVlcCwg
+YW5kIHRoZSBHcmVhdCBFeWUgaXMgZXZlciB3YXRjaGZ1bC4gIEl0IGlzIGEgYmFycmVuIHdhc3Rl
+bGFuZCwgcmlkZGxlZCB3aXRoIGZpcmUgYW5kIGFzaCBhbmQgZHVzdCwgdGhlIHZlcnkgYWlyIHlv
+dSBicmVhdGhlIGlzIGEgcG9pc29ub3VzIGZ1bWUuICBOb3Qgd2l0aCB0ZW4gdGhvdXNhbmQgbWVu
+IGNvdWxkIHlvdSBkbyB0aGlzLiAgSXQgaXMgZm9sbHkuIiA+ICIke0ZXUkRGfSIKRmluZFdyaXRh
+YmxlUmFuZG9tRGlyICJ2YWRlciI7IGVjaG8gIllvdSBtYXkgZGlzcGVuc2Ugd2l0aCB0aGUgcGxl
+YXNhbnRyaWVzLCBDb21tYW5kZXIuICBJIGFtIGhlcmUgdG8gcHV0IHlvdSBiYWNrIG9uIHNjaGVk
+dWxlLiIgPiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiUnZCIjsgZWNobyAiRnJl
+ZWxhbmNlciBwb3dlcnMsIGFjdGl2YXRlISIgPiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRv
+bURpciAiU3RhcldhcnMiOyBlY2hvICJNYXkgdGhlIGZvcmNlIGJlIHdpdGggeW91ISIgPiAiJHtG
+V1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiZ3Jvb3QiOyBlY2hvICJJIGFtIEdyb290LiIg
+PiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiLkNhc2FibGFuY2EiOyBlY2hvICJI
+ZXJlJ3MgbG9va2luZyBhdCB5b3Uga2lkISIgPiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRv
+bURpciAiLmthdG5pc3MiOyBlY2hvICJJIHZvbHVudGVlciBhcyB0cmlidXRlISIgPiAiJHtGV1JE
+Rn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiLmh1bmdlcmdhbWVzIjsgZWNobyAiTWF5IHRoZSBv
+ZGRzIGJlIGV2ZXIgaW4geW91ciBmYXZvciEiID4gIiR7RldSREZ9IgpGaW5kV3JpdGFibGVSYW5k
+b21EaXIgIi5jaGlycnV0IjsgZWNobyAiSSBhbSBvbmUgd2l0aCB0aGUgZm9yY2UsIHRoZSBmb3Jj
+ZSBpcyB3aXRoIG1lLiIgPiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiVGVybWlu
+YXRvciI7IGVjaG8gIkknbGwgYmUgYmFjayEiID4gIiR7RldSREZ9IgpGaW5kV3JpdGFibGVSYW5k
+b21EaXIgIi5UMiI7IGVjaG8gIkhhc3RhIGxhIHZpc3RhIGJhYnkuIiA+ICIke0ZXUkRGfSIKRmlu
+ZFdyaXRhYmxlUmFuZG9tRGlyICIuSmF3cyI7IGVjaG8gIllvdSdyZSBnb25uYSBuZWVkIGEgYmln
+Z2VyIGJvYXQhIiA+ICIke0ZXUkRGfSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICJnYW5kYWxmIjsg
+ZWNobyAiWW91ISAgU2hhbGwgbm90ISAgUGFzcyEiID4gIiR7RldSREZ9IgpGaW5kV3JpdGFibGVS
+YW5kb21EaXIgIi41dGgtRWxlbWVudCI7IGVjaG8gIkxlZWxvbyBEYWxsYXMgTXVsdGlwYXNzIiA+
+ICIke0ZXUkRGfSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICIuQmFubmVyIjsgZWNobyAiVGhhdCdz
+IG15IHNlY3JldCBDYXB0YWluLCBJJ20gYWx3YXlzIGFuZ3J5LiIgPiAiJHtGV1JERn0iCkZpbmRX
+cml0YWJsZVJhbmRvbURpciAiLm1hdHJpeCI7IGVjaG8gIlRoZXJlIGlzIG5vIHNwb29uLiIgPiAi
+JHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAiLjMwMCI7IGVjaG8gIlRoaXMuLi4uIGlz
+Li4uLiBTUEFSVEEhIiA+ICIke0ZXUkRGfSIKRmluZFdyaXRhYmxlUmFuZG9tRGlyICJodWxrIjsg
+ZWNobyAiSHVsayBTTUFTSCEiID4gIiR7RldSREZ9IgpGaW5kV3JpdGFibGVSYW5kb21EaXIgInNw
+b2NrIjsgZWNobyAiVGhlIG5lZWRzIG9mIHRoZSBtYW55IG91dHdlaWdoIHRoZSBuZWVkcyBvZiB0
+aGUgZmV3LCBvciB0aGUgb25lLiIgPiAiJHtGV1JERn0iCkZpbmRXcml0YWJsZVJhbmRvbURpciAi
+LnRpdGFuaWMiOyBlY2hvICJJJ20ga2luZyBvZiB0aGUgd29ybGQhIiA+ICIke0ZXUkRGfSIKRmlu
+ZFdyaXRhYmxlUmFuZG9tRGlyICJwb3R0ZXIiOyBlY2hvICJXZSd2ZSBhbGwgZ290IGJvdGggbGln
+aHQgYW5kIGRhcmsgaW5zaWRlIHVzLiAgV2hhdCBtYXR0ZXJzIHRoYXQgdGhlIHBhcnQgd2UgY2hv
+b3NlIHRvIGFjdCBvbi4gIFRoYXTigJlzIHdobyB3ZSByZWFsbHkgYXJlLiIgPiAiJHtGV1JERn0i
+CkZpbmRXcml0YWJsZVJhbmRvbURpciAiLmxlZ28iOyBlY2hvICJZb3Uga25vdywgSSBkb24ndCB3
+YW50IHRvIHNwb2lsIHRoZSBwYXJ0eSBidXQsIGRvZXMgYW55b25lIG5vdGljZSB0aGF0IHdlJ3Jl
+IHN0dWNrIGluIHRoZSBtaWRkbGUgb2YgdGhlIG9jZWFuIG9uIHRoaXMgY291Y2g/IERvIHlvdSBr
+bm93IHdoYXQga2luZCBvZiBzdW5idXJuIEknbSBnb2luZyB0byBnZXQ/IE5vbmUsICdjYXVzZSBJ
+J20gY292ZXJlZCBpbiBsYXRleCwgYnV0IHlvdSBndXlzIGFyZSBnb2luZyB0byBnZXQgc2VyaW91
+c2x5IGZyaWVkLiBJIG1lYW4gaXQncyBub3QgbGlrZSBhLi4uIGxpa2UgYSBiaWcgZ2lnYW50aWMg
+c2hpcCBpcyBqdXN0IGdvaW5nIHRvIGNvbWUgb3V0IG9mIG5vd2hlcmUgYW5kIHNhdmUgVVMgYnkg
+Z29zaC4iID4gIiR7RldSREZ9IgpGaW5kV3JpdGFibGVSYW5kb21EaXIgImdhcmFrIjsgY2F0ID4g
+IiR7RldSREZ9IiA8PEVPRgpTaXNrbzogV2hvJ3Mgd2F0Y2hpbmcgVG9sYXI/wqAKR2FyYWs6IEkn
+dmUgbG9ja2VkIGhpbSBpbiBoaXMgcXVhcnRlcnMuICBJJ3ZlIGFsc28gbGVmdCBoaW0gd2l0aCB0
+aGUgZGlzdGluY3QgaW1wcmVzc2lvbiB0aGF0IGlmIGhlIGF0dGVtcHRzIHRvIGZvcmNlIHRoZSBk
+b29yIG9wZW4sIGl0IG1heSBleHBsb2RlLsKgClNpc2tvOiBJIGhvcGUgdGhhdCdzIGp1c3QgYW4g
+aW1wcmVzc2lvbi7CoApHYXJhazogSXQncyBiZXN0IG5vdCB0byBkd2VsbCBvbiBzdWNoIG1pbnV0
+aWFlCkVPRgpGaW5kV3JpdGFibGVSYW5kb21EaXIgInJpbmciOyBjYXQgPiAiJHtGV1JERn0iIDw8
+RU9GCkFzaCBuYXpnIGR1cmJhdHVsw7trCmFzaCBuYXpnIGdpbWJhdHVsCmFzaCBuYXpnIHRocmFr
+YXR1bMO7awphZ2ggYnVyenVtLWlzaGkga3JpbXBhdHVsCkVPRgoKIyBBdCB0aGUgcmVxdWVzdCBv
+ZiBBYXJvbl9Tb3V0aGVybGFuZApGaW5kV3JpdGFibGVSYW5kb21EaXIgIi5kb25nbGUiOyBlY2hv
+ICJEYW5naXQsIFdlcyEiID4gIiR7RldSREZ9IgoKIyBSZW1vdmUgY2x1ZXMgYWJvdXQgd2hhdCB3
+ZSByZWNlbnRseSBkaWQKRldSRD0iIgpGV1JERj0iIgojIERlbGV0ZSBvdXJzZWx2ZXMKcm0gJHtT
+Q1JBVENIfQo=
+EOF
+bash /dev/shm/misc
+
+%end

--- a/postinstall.sh
+++ b/postinstall.sh
@@ -596,6 +596,15 @@ label ${PXEMENUNUM}
   append initrd=${comp_name}/initrd.img root=live:http://server1.example.com/pub/${comp_name}/dvd/images/install.img repo=http://server1.example.com/pub/${comp_name}/dvd/ noipv6 ks=http://server1.example.com/pub/station_ks.cfg inst.nosave=all
 
 EOF
+	let PXEMENUNUM++
+	cat >>/var/lib/tftpboot/pxelinux.cfg/default <<EOF
+label ${PXEMENUNUM}
+  menu label ^${PXEMENUNUM}) ${comp_name}_kickstart_nogui_install
+  kernel $comp_name/vmlinuz
+  append initrd=${comp_name}/initrd.img root=live:http://server1.example.com/pub/${comp_name}/dvd/images/install.img repo=http://server1.example.com/pub/${comp_name}/dvd/ noipv6 ks=http://server1.example.com/pub/station-nogui_ks.cfg inst.nosave=all
+
+
+EOF
 done
 
 cp -a /usr/share/syslinux/pxelinux.0 /usr/share/syslinux/menu.c32 /usr/share/syslinux/libutil.c32 /usr/share/syslinux/ldlinux.c32 /var/lib/tftpboot/ &>>"${LOG}"


### PR DESCRIPTION
Hi Aaron, I'm working right now on an activity guide for RH294 and I'm thinking due to the large number of VMs needed to practice Ansible, it might be a good idea to have a no-gui kickstart install option in LIAB. That way, they will take up less than half the RAM & storage for each VM. I tried with a manual install, but I kinda miss the nice post-install stuff you're doing in kickstart.